### PR TITLE
Add custom error handling while unmarshalling request body

### DIFF
--- a/internal/pkg/pac-go-server/models/feedback.go
+++ b/internal/pkg/pac-go-server/models/feedback.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -21,7 +20,7 @@ type Feedback struct {
 	ID      primitive.ObjectID `json:"id" bson:"_id,omitempty"`
 	UserID  string             `json:"user_id" bson:"user_id,omitempty"`
 	Rating  Rating             `json:"rating" bson:"rating,omitempty"`
-	Comment string             `json:"comment" bson:"comment,omitempty"`
+	Comment string             `json:"comment" bson:"comment,omitempty" binding:"max=250"`
 	// CreatedAt is the time the event was created
 	CreatedAt time.Time `json:"created_at" bson:"created_at"`
 }
@@ -40,15 +39,12 @@ type FeedbacksFilter struct {
 	UserID string
 }
 
-func (f Feedback) ValidateFeedback() []error {
-	var errs []error
+func (f Feedback) ValidateFeedback() error {
+	var err error
 	if !f.Rating.IsValidRating() {
-		errs = append(errs, fmt.Errorf("invalid rating %s, allowed values: Negative, Neutral, Positive", f.Rating))
+		return fmt.Errorf("invalid rating %s, allowed values: Negative, Neutral, Positive", f.Rating)
 	}
-	if len(f.Comment) > 250 {
-		errs = append(errs, errors.New("comment must not exceed 250 characters"))
-	}
-	return errs
+	return err
 }
 
 func (r Rating) IsValidRating() bool {

--- a/internal/pkg/pac-go-server/services/catalog.go
+++ b/internal/pkg/pac-go-server/services/catalog.go
@@ -88,9 +88,8 @@ func CreateCatalog(c *gin.Context) {
 	originator := c.Request.Context().Value("userid").(string)
 	logger := log.GetLogger()
 	catalog := models.Catalog{}
-	if err := c.BindJSON(&catalog); err != nil {
+	if err := utils.BindAndValidate(c, &catalog); err != nil {
 		logger.Error("failed to bind request", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to bind request, Error: %v", err.Error())})
 		return
 	}
 

--- a/internal/pkg/pac-go-server/services/feedback.go
+++ b/internal/pkg/pac-go-server/services/feedback.go
@@ -29,16 +29,15 @@ const (
 // @Router			/api/v1/feedbacks [post]
 func CreateFeedback(c *gin.Context) {
 	var feedback *models.Feedback
-	if err := c.BindJSON(&feedback); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	if err := utils.BindAndValidate(c, &feedback); err != nil {
 		return
 	}
 	userID := c.Request.Context().Value("userid").(string)
 	feedback.UserID = userID
 	feedback.CreatedAt = time.Now()
 	logger := log.GetLogger()
-	if err := feedback.ValidateFeedback(); len(err) > 0 {
-		logger.Error("error while validating feedback request", zap.Errors("errors", err))
+	if err := feedback.ValidateFeedback(); err != nil {
+		logger.Error("error while validating feedback request", zap.Error(err))
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%v", err)})
 		return
 	}

--- a/internal/pkg/pac-go-server/services/key.go
+++ b/internal/pkg/pac-go-server/services/key.go
@@ -85,8 +85,7 @@ func CreateKey(c *gin.Context) {
 	// Step0: Get the authenticated user's ID
 	userID := c.Request.Context().Value("userid").(string)
 
-	if err := c.BindJSON(&key); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	if err := utils.BindAndValidate(c, &key); err != nil {
 		return
 	}
 	key.UserID = userID

--- a/internal/pkg/pac-go-server/services/quota.go
+++ b/internal/pkg/pac-go-server/services/quota.go
@@ -77,9 +77,8 @@ func CreateQuota(c *gin.Context) {
 		return
 	}
 
-	if err := c.BindJSON(&quota); err != nil {
+	if err := utils.BindAndValidate(c, &quota); err != nil {
 		logger.Error("error while creating quota for group", zap.String("id", gid), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -144,9 +143,8 @@ func UpdateQuota(c *gin.Context) {
 		return
 	}
 
-	if err := c.BindJSON(&quota); err != nil {
+	if err := utils.BindAndValidate(c, &quota); err != nil {
 		logger.Error("error while updating quota", zap.String("groupID", gid), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/pkg/pac-go-server/services/request.go
+++ b/internal/pkg/pac-go-server/services/request.go
@@ -101,9 +101,8 @@ func UpdateServiceExpiryRequest(c *gin.Context) {
 	var request = models.GetRequest()
 	userID := c.Request.Context().Value("userid").(string)
 
-	if err := c.BindJSON(&request); err != nil {
+	if err := utils.BindAndValidate(c, &request); err != nil {
 		logger.Error("failed to bind request", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	logger.Debug("request body", zap.Any("request", request))
@@ -228,9 +227,8 @@ func NewGroupRequest(c *gin.Context) {
 	username := c.Request.Context().Value("username").(string)
 	userID := c.Request.Context().Value("userid").(string)
 
-	if err := c.BindJSON(&request); err != nil {
+	if err := utils.BindAndValidate(c, &request); err != nil {
 		logger.Error("failed to bind request", zap.Error(err))
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	logger.Debug("request body", zap.Any("request", request))
@@ -333,9 +331,8 @@ func ExitGroup(c *gin.Context) {
 	username := c.Request.Context().Value("username").(string)
 	userID := c.Request.Context().Value("userid").(string)
 
-	if err := c.BindJSON(&request); err != nil {
+	if err := utils.BindAndValidate(c, &request); err != nil {
 		logger.Error("failed to bind request", zap.Error(err))
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to bind request body, err: %s", err.Error())})
 		return
 	}
 	logger.Debug("request body", zap.Any("request", request))
@@ -661,9 +658,8 @@ func RejectRequest(c *gin.Context) {
 	}
 
 	var request models.Request
-	if err := c.BindJSON(&request); err != nil {
+	if err := utils.BindAndValidate(c, &request); err != nil {
 		logger.Error("failed to bind request", zap.Error(err))
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to load the body, please feed the proper json body: %s", err)})
 		return
 	}
 

--- a/internal/pkg/pac-go-server/services/service.go
+++ b/internal/pkg/pac-go-server/services/service.go
@@ -140,9 +140,8 @@ func CreateService(c *gin.Context) {
 	logger := log.GetLogger()
 	service := models.Service{}
 	// bind user request
-	if err := c.BindJSON(&service); err != nil {
-		logger.Error("failed to bin request", zap.Error(err))
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to bind request, Error: %v", err.Error())})
+	if err := utils.BindAndValidate(c, &service); err != nil {
+		logger.Error("failed to bind request", zap.Error(err))
 		return
 	}
 	logger.Debug("create service request", zap.Any("request", service))

--- a/internal/pkg/pac-go-server/utils/errors.go
+++ b/internal/pkg/pac-go-server/utils/errors.go
@@ -1,6 +1,12 @@
 package utils
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/go-playground/validator/v10"
+)
 
 var (
 	errInvalidCapacity       = errors.New("minimum supported values for CPU and memory capacity on PowerVS is 0.25C and 2GB respectively")
@@ -9,3 +15,39 @@ var (
 	ErrResourceAlreadyExists = errors.New("requested resource already exists")
 	ErrNotAuthorized         = errors.New("user does not have permission to delete this key")
 )
+
+func translateValidationError(fe validator.FieldError) string {
+	switch fe.Tag() {
+	case "required":
+		return fmt.Sprintf("%s is required", fe.Field())
+	case "gte":
+		return fmt.Sprintf("%s must be greater than or equal to %s", fe.Field(), fe.Param())
+	case "lte":
+		return fmt.Sprintf("%s must be less than or equal to %s", fe.Field(), fe.Param())
+	case "max":
+		return fmt.Sprintf("%s must not exceed %s characters", fe.Field(), fe.Param())
+	case "uuid":
+		return fmt.Sprintf("%s must be a valid UUID", fe.Field())
+	default:
+		return fmt.Sprintf("%s is invalid", fe.Field())
+	}
+}
+
+func getExpectedType(t reflect.Type) string {
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return "number"
+	case reflect.Bool:
+		return "boolean"
+	case reflect.String:
+		return "string"
+	case reflect.Slice, reflect.Array:
+		return "array"
+	case reflect.Map, reflect.Struct:
+		return "object"
+	default:
+		return "value"
+	}
+}

--- a/internal/pkg/pac-go-server/utils/errors_test.go
+++ b/internal/pkg/pac-go-server/utils/errors_test.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetExpectedType_AllKinds(t *testing.T) {
+	type customStruct struct {
+		Foo string
+	}
+
+	tests := []struct {
+		name     string
+		typ      reflect.Type
+		expected string
+	}{
+		{
+			name:     "int",
+			typ:      reflect.TypeOf(int(0)),
+			expected: "number",
+		},
+		{
+			name:     "uint64",
+			typ:      reflect.TypeOf(uint64(0)),
+			expected: "number",
+		},
+		{
+			name:     "float64",
+			typ:      reflect.TypeOf(float64(0)),
+			expected: "number",
+		},
+		{
+			name:     "bool",
+			typ:      reflect.TypeOf(true),
+			expected: "boolean",
+		},
+		{
+			name:     "string",
+			typ:      reflect.TypeOf("hello"),
+			expected: "string",
+		},
+		{
+			name:     "slice",
+			typ:      reflect.TypeOf([]int{1, 2, 3}),
+			expected: "array",
+		},
+		{
+			name:     "array",
+			typ:      reflect.TypeOf([3]int{1, 2, 3}),
+			expected: "array",
+		},
+		{
+			name:     "map",
+			typ:      reflect.TypeOf(map[string]int{}),
+			expected: "object",
+		},
+		{
+			name:     "struct",
+			typ:      reflect.TypeOf(customStruct{}),
+			expected: "object",
+		},
+		{
+			name:     "chan (default case)",
+			typ:      reflect.TypeOf(make(chan int)),
+			expected: "value",
+		},
+		{
+			name:     "pointer (default case)",
+			typ:      reflect.TypeOf(&customStruct{}),
+			expected: "value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getExpectedType(tt.typ)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/internal/pkg/pac-go-server/utils/utils_test.go
+++ b/internal/pkg/pac-go-server/utils/utils_test.go
@@ -1,0 +1,163 @@
+package utils_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PDeXchange/pac/internal/pkg/pac-go-server/models"
+	"github.com/PDeXchange/pac/internal/pkg/pac-go-server/utils"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRequest is the test model to validate BindAndValidate with other tags.
+type TestRequest struct {
+	Name   string `json:"name" binding:"required"`
+	Length string `json:"length" binding:"gte=5,lte=10"`
+	Age    int    `json:"age" binding:"gte=18,lte=60"`
+}
+
+func performRequest(body string, model any) (*httptest.ResponseRecorder, error) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	err := utils.BindAndValidate(c, model)
+	return w, err
+}
+
+func TestBindAndValidate_AllCases(t *testing.T) {
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	tests := []struct {
+		name           string
+		body           string
+		model          any
+		expectOK       bool
+		expectHTTPCode int
+		expectField    string
+		expectError    error
+	}{
+		{
+			name:           "success",
+			body:           `{"id":"507f1f77bcf86cd799439011","user_id":"user123","rating":"positive","comment":"great","created_at":"` + now + `"}`,
+			model:          &models.Feedback{},
+			expectOK:       true,
+			expectHTTPCode: 200,
+		},
+		{
+			name:           "comment too long (max=250)",
+			body:           `{"id":"507f1f77bcf86cd799439011","user_id":"user123","rating":"neutral","comment":"` + strings.Repeat("a", 300) + `","created_at":"` + now + `"}`,
+			model:          &models.Feedback{},
+			expectOK:       false,
+			expectHTTPCode: 400,
+			expectField:    "Comment",
+			expectError:    errors.New("Comment must not exceed 250 characters"),
+		},
+		{
+			name:           "rating type mismatch (string expected)",
+			body:           `{"id":"507f1f77bcf86cd799439011","user_id":"user123","rating":123,"comment":"ok","created_at":"` + now + `"}`,
+			model:          &models.Feedback{},
+			expectOK:       false,
+			expectHTTPCode: 400,
+			expectField:    "rating",
+			expectError:    errors.New("Field 'rating' must be string"),
+		},
+		{
+			name:           "created_at type mismatch",
+			body:           `{"id":"507f1f77bcf86cd799439011","user_id":"user123","rating":"positive","comment":"ok","created_at":12345}`,
+			model:          &models.Feedback{},
+			expectOK:       false,
+			expectHTTPCode: 400,
+			expectError:    errors.New("invalid request body"),
+		},
+		{
+			name:           "malformed JSON",
+			body:           `{"id":"5507f1f77bcf86cd799439011","user_id":"user123","rating":"positive","comment":"ok","created_at":"` + now, // broken JSON
+			model:          &models.Feedback{},
+			expectOK:       false,
+			expectHTTPCode: 400,
+			expectError:    errors.New("invalid request body"),
+		},
+		{
+			name:           "missing required field",
+			body:           `{"length":"abcdef","age":25}`,
+			model:          &TestRequest{},
+			expectOK:       false,
+			expectHTTPCode: 400,
+			expectField:    "Name",
+			expectError:    errors.New("Name is required"),
+		},
+		{
+			name:           "length too short (gte violation)",
+			body:           `{"name":"foo","length":"abc","age":25}`,
+			model:          &TestRequest{},
+			expectOK:       false,
+			expectHTTPCode: 400,
+			expectField:    "Length",
+			expectError:    errors.New("Length must be greater than or equal to 5"),
+		},
+		{
+			name:           "length too long (lte violation)",
+			body:           `{"name":"foo","length":"abcdefghijk","age":25}`,
+			model:          &TestRequest{},
+			expectOK:       false,
+			expectHTTPCode: 400,
+			expectField:    "Length",
+			expectError:    errors.New("Length must be less than or equal to 10"),
+		},
+		{
+			name:           "age below minimum",
+			body:           `{"name":"foo","length":"abcdef","age":15}`,
+			model:          &TestRequest{},
+			expectOK:       false,
+			expectHTTPCode: 400,
+			expectField:    "Age",
+			expectError:    errors.New("Age must be greater than or equal to 18"),
+		},
+		{
+			name:           "age above maximum",
+			body:           `{"name":"foo","length":"abcdef","age":70}`,
+			model:          &TestRequest{},
+			expectOK:       false,
+			expectHTTPCode: 400,
+			expectField:    "Age",
+			expectError:    errors.New("Age must be less than or equal to 60"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := performRequest(tt.body, tt.model)
+
+			if tt.expectOK {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectHTTPCode, w.Code)
+				return
+			}
+
+			assert.Error(t, err)
+			assert.Equal(t, tt.expectHTTPCode, w.Code)
+
+			var resp map[string]any
+			_ = json.Unmarshal(w.Body.Bytes(), &resp)
+
+			if tt.expectField != "" {
+				assert.Equal(t, tt.expectField, resp["field"])
+			}
+			if tt.expectError != nil {
+				assert.Equal(t, tt.expectError.Error(), resp["error"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Restrict information shown in case of request body unmarshalling.
- Use custom errors to specify descriptive and less informative error to user.
<img width="387" height="391" alt="Screenshot 2025-09-17 at 09 29 05" src="https://github.com/user-attachments/assets/a22d04fe-5e19-418b-8b87-8dbcea6a6039" />
